### PR TITLE
package.json: fix repo link

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "test": "standard --format && mocha",
     "build": "npm test && node build.js > index.json"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/zeke/npm-pronouncing-dictionary"
-  },
+  "repository": "zeke/cmu-pronouncing-dictionary",
   "keywords": [
     "english",
     "language",


### PR DESCRIPTION
Noticed the link to the GH repo on npm was broken. This fixes it. Thanks!

## Changes
- __pkg__: fixed repo link and moved to shorthand notation